### PR TITLE
feat/lib edit admin

### DIFF
--- a/holy-grail-frontend/src/features/Library/NotesApplication.tsx
+++ b/holy-grail-frontend/src/features/Library/NotesApplication.tsx
@@ -16,7 +16,7 @@ import deleteNote from "../../utils/actions/DeleteNote";
 import updateNote from "../../utils/actions/UpdateNote";
 import AdminDeleteIcon from "../../components/AdminDeleteIcon/AdminDeleteIcon";
 import AdminEditIcon from "../../components/AdminEditIcon/AdminEditIcon";
-import { Box } from "@chakra-ui/react";
+import { Box } from "@mui/material";
 
 const NotesApplication = () => {
   const [notes, setNotes] = useState<PaginatedNotes>({


### PR DESCRIPTION
this PR implements the edit button for /library for users logged in as admin. This allows admins to edit approved notes already on the library.