### PR TITLE
fix: rewrite components in mui

### DIFF
--- a/holy-grail-frontend/src/components/AccountForm/AccountForm.tsx
+++ b/holy-grail-frontend/src/components/AccountForm/AccountForm.tsx
@@ -1,21 +1,20 @@
-import { Box, BoxProps, Flex } from "@chakra-ui/react";
+import { Box, BoxProps } from "@mui/material";
 
 export const AccountForm = ({ children }: BoxProps) => {
   return (
     <>
-      <Flex
-        flexDirection="column"
-        display="flex"
-        alignItems="center"
-        width={["80%", "100%"]}
-        minH="85vh"
-        ml="auto"
-        mr="auto"
-        mt="10%"
-        mb="10%"
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          width: "100%",
+          minHeight: "85vh",
+          margin: "10% auto 10% auto",
+        }}
       >
-        <Box textAlign="left">{children}</Box>
-      </Flex>
+        <Box sx={{ textAlign: "left" }}>{children}</Box>
+      </Box>
     </>
   );
 };

--- a/holy-grail-frontend/src/components/HeroBox/HeroBox.tsx
+++ b/holy-grail-frontend/src/components/HeroBox/HeroBox.tsx
@@ -1,8 +1,8 @@
-import { Box, BoxProps } from "@chakra-ui/react";
+import { Box, BoxProps } from "@mui/material";
 
 export const HeroBox = ({ children, ...props }: BoxProps) => {
   return (
-    <Box w="30%" {...props}>
+    <Box sx={{ width: "30%" }} {...props}>
       {children}
     </Box>
   );

--- a/holy-grail-frontend/src/components/HomeButton/HomeButton.tsx
+++ b/holy-grail-frontend/src/components/HomeButton/HomeButton.tsx
@@ -1,25 +1,28 @@
-import { Button } from "@chakra-ui/react";
+import { Button } from "@mui/material";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { ButtonHTMLAttributes, forwardRef } from "react";
-import { Text } from "../Text/Text";
 
 export const HomeButton = forwardRef<
   HTMLButtonElement,
   ButtonHTMLAttributes<HTMLButtonElement>
->(({ children, ...props }, ref) => {
+>(({ children }, ref) => {
+  const muiTheme = createTheme();
   return (
-    <>
+    <ThemeProvider theme={muiTheme}>
       <Button
         ref={ref}
-        variant="outline"
-        borderColor="black"
-        bg="white"
-        px="30"
-        h="40px"
-        {...props}
+        variant="outlined"
+        sx={{
+          borderColor: "black",
+          backgroundColor: "white",
+          paddingX: "30px",
+          height: "40px",
+          textTransform: "capitalize",
+        }}
       >
         <div className="button-text">{children}</div>
       </Button>
-    </>
+    </ThemeProvider>
   );
 });
 

--- a/holy-grail-frontend/src/components/Pagination/Pagination.tsx
+++ b/holy-grail-frontend/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,6 @@
-import { Button, HStack, Text } from "@chakra-ui/react";
+import { AspectRatio } from "@chakra-ui/react";
+import { Stack, Button, Typography } from "@mui/material";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
 import debounce from "lodash/debounce";
 
 interface PaginationProps {
@@ -13,28 +15,48 @@ export const Pagination = ({
   styles,
 }: PaginationProps) => {
   const debouncedHandlePageChange = debounce(handlePageChange, 100);
+  const muiTheme = createTheme();
+  const buttonStyles = {
+    borderColor: "transparent",
+    backgroundColor: "rgb(237, 242, 247)",
+    textTransform: "capitalize",
+    color: "black",
+    fontWeight: "bold",
+    aspectRatio: 1.618,
+    borderRadius: "10%",
+  };
 
   return (
-    <HStack
-      spacing={4}
-      justifyContent="center"
-      mt={styles?.mt ? styles.mt : "10%"}
-    >
-      <Button
-        onClick={() => debouncedHandlePageChange(pageInfo.page - 1)}
-        isDisabled={pageInfo.page === 1}
+    <ThemeProvider theme={muiTheme}>
+      <Stack
+        spacing={2}
+        direction="row"
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          marginTop: styles?.mt ? styles.mt : "10%",
+        }}
       >
-        Prev
-      </Button>
-      <Text>
-        Page {pageInfo.page} of {pageInfo.pages > 0 ? pageInfo.pages : 1}
-      </Text>
-      <Button
-        onClick={() => debouncedHandlePageChange(pageInfo.page + 1)}
-        isDisabled={pageInfo.page === pageInfo.pages || pageInfo.pages === 0}
-      >
-        Next
-      </Button>
-    </HStack>
+        <Button
+          onClick={() => debouncedHandlePageChange(pageInfo.page - 1)}
+          disabled={pageInfo.page === 1}
+          variant="outlined"
+          sx={buttonStyles}
+        >
+          Prev
+        </Button>
+        <Typography display="flex" alignItems="center">
+          Page {pageInfo.page} of {pageInfo.pages > 0 ? pageInfo.pages : 1}
+        </Typography>
+        <Button
+          onClick={() => debouncedHandlePageChange(pageInfo.page + 1)}
+          disabled={pageInfo.page === pageInfo.pages || pageInfo.pages === 0}
+          variant="outlined"
+          sx={buttonStyles}
+        >
+          Next
+        </Button>
+      </Stack>
+    </ThemeProvider>
   );
 };

--- a/holy-grail-frontend/src/components/Text/Text.tsx
+++ b/holy-grail-frontend/src/components/Text/Text.tsx
@@ -1,14 +1,14 @@
-import { Text as ChakraText, TextProps } from "@chakra-ui/react";
+import { Typography, TypographyProps } from "@mui/material";
 
-export const Text = ({ children, ...props }: TextProps) => {
+export const Text = ({ children, ...props }: TypographyProps) => {
   return (
-    <ChakraText
+    <Typography
       fontFamily="Trebuchet MS, sans-serif"
       color="black"
       fontSize={["sm", "md", "lg", "xl"]}
       {...props}
     >
       {children}
-    </ChakraText>
+    </Typography>
   );
 };

--- a/holy-grail-frontend/src/components/TextLink/TextLink.tsx
+++ b/holy-grail-frontend/src/components/TextLink/TextLink.tsx
@@ -1,14 +1,14 @@
-import { TextProps } from "@chakra-ui/react";
+import { Typography, TypographyProps } from "@mui/material";
 import { Text } from "../Text/Text";
 
-type TextLinkProps = TextProps & {
+type TextLinkProps = TypographyProps & {
   children: string;
 };
 
 export const TextLink = ({ children, ...props }: TextLinkProps) => {
   return (
-    <Text cursor="pointer" {...props}>
+    <Typography sx={{ cursor: "pointer" }} {...props}>
       {children}
-    </Text>
+    </Typography>
   );
 };

--- a/holy-grail-frontend/src/components/Title/Title.tsx
+++ b/holy-grail-frontend/src/components/Title/Title.tsx
@@ -1,8 +1,8 @@
-import { Text as ChakraText, TextProps } from "@chakra-ui/react";
+import { Typography, TypographyProps } from "@mui/material";
 
-export const Title = ({ children, ...props }: TextProps) => {
+export const Title = ({ children, ...props }: TypographyProps) => {
   return (
-    <ChakraText
+    <Typography
       fontWeight="bold"
       fontSize={["xl", "3xl", "5xl", "7xl"]}
       color="black"
@@ -10,6 +10,6 @@ export const Title = ({ children, ...props }: TextProps) => {
       {...props}
     >
       {children}
-    </ChakraText>
+    </Typography>
   );
 };


### PR DESCRIPTION
This PR rewrites all components in ``holy-grail-frontend/src/components/`` directory from chakra to mui. See attached visual changes, though I wanted to make sure everything looked similar/the same.