### PR TITLE
refactor: make isDesktop globally usable

### DIFF
--- a/holy-grail-frontend/src/App.tsx
+++ b/holy-grail-frontend/src/App.tsx
@@ -18,6 +18,7 @@ import AccountVerifyPage from './features/AccountVerify/AccountVerifyPage';
 import AlertToast, { AlertProps } from './components/AlertToast/AlertToast';
 
 import Header from './features/Header/Header';
+import { MediaQueryProvider } from './providers/MediaQueryProvider';
 
 function App() {
   const [alertContent, setAlertContent] = useState<AlertProps | undefined>(undefined);
@@ -32,31 +33,33 @@ function App() {
   }, [location.state]);
 
   return (
-    <AuthProvider>
-      <ChakraProvider>
-        <Header />
-        <Routes>
-          <Route path='/' element={<LandingPage />} />
-          <Route path='/login' element={<LoginPage />} />
-          <Route path='/register' element={<SignUpPage />} />
-          <Route path='/upload' element={<UploadPage />} />
-          <Route path='/admin' element={<ApprovalPage />} />
-          <Route path='/developer' element={<DeveloperPage />} />
-          <Route path='/forgot-password' element={<ForgotPasswordPage />} />
-          <Route path='/update-password' element={<ChangePasswordPage />} />
-          <Route path='/reset-password' element={<ResetPasswordPage />} />
-          <Route path='/verify-account' element={<AccountVerifyPage />} />
-          <Route path='*' element={<NotFound />} />
-        </Routes>
-        <Footer />
+    <MediaQueryProvider>
+      <AuthProvider>
+        <ChakraProvider>
+          <Header />
+          <Routes>
+            <Route path='/' element={<LandingPage />} />
+            <Route path='/login' element={<LoginPage />} />
+            <Route path='/register' element={<SignUpPage />} />
+            <Route path='/upload' element={<UploadPage />} />
+            <Route path='/admin' element={<ApprovalPage />} />
+            <Route path='/developer' element={<DeveloperPage />} />
+            <Route path='/forgot-password' element={<ForgotPasswordPage />} />
+            <Route path='/update-password' element={<ChangePasswordPage />} />
+            <Route path='/reset-password' element={<ResetPasswordPage />} />
+            <Route path='/verify-account' element={<AccountVerifyPage />} />
+            <Route path='*' element={<NotFound />} />
+          </Routes>
+          <Footer />
 
-        <AlertToast
-          openAlert={openAlert}
-          onClose={() => setOpenAlert(false)}
-          alertContent={alertContent}
-        />
-      </ChakraProvider>
-    </AuthProvider>
+          <AlertToast
+            openAlert={openAlert}
+            onClose={() => setOpenAlert(false)}
+            alertContent={alertContent}
+          />
+        </ChakraProvider>
+      </AuthProvider>
+    </MediaQueryProvider>
   );
 }
 

--- a/holy-grail-frontend/src/components/NotesTable/NotesTable.tsx
+++ b/holy-grail-frontend/src/components/NotesTable/NotesTable.tsx
@@ -6,7 +6,8 @@ import Combobox from '../../features/Library/Combobox';
 import { ComboboxProps } from '../../features/Library/Combobox';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { Pagination } from '../Pagination/Pagination';
-import { useMediaQuery } from 'react-responsive';
+import { useContext } from 'react';
+import MediaQueryContext from '../../providers/MediaQueryProvider';
 import '../../features/Library/library.css';
 import NotesIcon from './notesHelper';
 
@@ -56,7 +57,7 @@ const NotesTable = ({
   isAdmin,
 }: NotesTableProps) => {
   const muiTheme = createTheme();
-  const isMobile = useMediaQuery({ query: '(max-width: 600px)' });
+  const { isDesktop } = useContext(MediaQueryContext);
 
   return (
     <Box>
@@ -64,7 +65,7 @@ const NotesTable = ({
         <Box display='flex' flexDirection='column' alignItems='center'>
           <Box
             display='flex'
-            flexDirection={isMobile ? 'column' : 'row'}
+            flexDirection={isDesktop ? 'row' : 'column'}
             gap={2}
             marginBottom={2}
             sx={{ width: '100%' }}
@@ -79,7 +80,7 @@ const NotesTable = ({
                 handlePageChange(1);
               }}
               options={categories}
-              style={{ width: isMobile ? '100%' : '15%' }}
+              style={{ width: isDesktop ? '15%' : '100%' }}
             />
             <Combobox
               label='Subject'
@@ -89,7 +90,7 @@ const NotesTable = ({
                 handlePageChange(1);
               }}
               options={subjects}
-              style={{ width: isMobile ? '100%' : '15%' }}
+              style={{ width: isDesktop ? '15%' : '100%' }}
             />
             <Combobox
               label='Type'
@@ -99,10 +100,10 @@ const NotesTable = ({
                 handlePageChange(1);
               }}
               options={types}
-              style={{ width: isMobile ? '100%' : '15%' }}
+              style={{ width: isDesktop ? '15%' : '100%' }}
             />
           </Box>
-          {!isMobile ? (
+          {isDesktop ? (
             <TableContainer>
               <Table className='table__notes'>
                 <TableHead>

--- a/holy-grail-frontend/src/components/Pagination/Pagination.tsx
+++ b/holy-grail-frontend/src/components/Pagination/Pagination.tsx
@@ -1,7 +1,8 @@
 import { Stack, Button, Typography } from '@mui/material';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import debounce from 'lodash/debounce';
-import { useMediaQuery } from 'react-responsive';
+import { useContext } from 'react';
+import MediaQueryContext from '../../providers/MediaQueryProvider';
 
 interface PaginationProps {
   pageInfo: { page: number; size: number; total: number; pages: number };
@@ -22,8 +23,8 @@ export const Pagination = ({ pageInfo, handlePageChange, styles }: PaginationPro
     borderRadius: '10%',
   };
 
-  const isMobile = useMediaQuery({ query: '(max-width: 600px)' });
-  const responsiveMt = isMobile ? '20%' : '4%';
+  const { isDesktop } = useContext(MediaQueryContext);
+  const responsiveMt = isDesktop ? '4%' : '20%';
 
   return (
     <ThemeProvider theme={muiTheme}>

--- a/holy-grail-frontend/src/features/Header/Header.tsx
+++ b/holy-grail-frontend/src/features/Header/Header.tsx
@@ -3,23 +3,17 @@ import { useContext, useState } from 'react';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import Logo from '../../assets/placeholder.svg';
 import AuthContext from '../../providers/AuthProvider';
-import {
-  IconButton,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
-  useBreakpointValue,
-} from '@chakra-ui/react';
+import { IconButton, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
 import { resendVerificationEmail } from '../../api/utils/auth/ResendVerificationEmail';
 import { HamburgerIcon } from '@chakra-ui/icons';
 import { HeaderRightButton } from './HeaderRightButton';
 import AlertToast, { AlertProps } from '../../components/AlertToast/AlertToast';
+import MediaQueryContext from '../../providers/MediaQueryProvider';
 
 const Header = () => {
   const { user, logout } = useContext(AuthContext);
   const navigate = useNavigate();
-  const isDesktop = useBreakpointValue({ base: false, lg: true });
+  const { isDesktop } = useContext(MediaQueryContext);
   const [activeNav, setActiveNav] = useState('#home');
 
   const [openAlert, setOpenAlert] = useState<boolean>(false);

--- a/holy-grail-frontend/src/features/Landing/FAQLine.tsx
+++ b/holy-grail-frontend/src/features/Landing/FAQLine.tsx
@@ -1,13 +1,8 @@
-import {
-  AccordionItem,
-  AccordionButton,
-  AccordionPanel,
-  Box,
-  useBreakpointValue,
-} from '@chakra-ui/react';
+import { AccordionItem, AccordionButton, AccordionPanel, Box } from '@chakra-ui/react';
 import { AddIcon, MinusIcon } from '@chakra-ui/icons';
 import { Text } from '../../components/Text/Text';
-import { ReactNode } from 'react';
+import { ReactNode, useContext } from 'react';
+import MediaQueryContext from '../../providers/MediaQueryProvider';
 
 type FAQLineProps = {
   question: string;
@@ -15,7 +10,7 @@ type FAQLineProps = {
 };
 
 const FAQLine = ({ question, children }: FAQLineProps) => {
-  const isDesktop = useBreakpointValue({ base: false, lg: true });
+  const { isDesktop } = useContext(MediaQueryContext);
 
   return (
     <AccordionItem borderColor='transparent'>

--- a/holy-grail-frontend/src/features/Upload/UploadPage.tsx
+++ b/holy-grail-frontend/src/features/Upload/UploadPage.tsx
@@ -1,12 +1,11 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useContext } from 'react';
 import { Button, Text, Input } from '@chakra-ui/react';
 import Combobox from '../Library/Combobox';
 import { fetchData, CategoryType, SubjectType, DocumentType } from '../../api/utils/library/Search';
 import { createNote } from '../../api/utils/actions/CreateNote';
-import { useContext } from 'react';
 import AuthContext from '../../providers/AuthProvider';
 import { useNavigate } from 'react-router-dom';
-import { useMediaQuery } from 'react-responsive';
+import MediaQueryContext from '../../providers/MediaQueryProvider';
 import AlertToast, { AlertProps } from '../../components/AlertToast/AlertToast';
 import './upload.css';
 
@@ -29,7 +28,7 @@ const UploadPage = () => {
 
   const { user } = useContext(AuthContext);
   const navigate = useNavigate();
-  const isMobile = useMediaQuery({ query: '(max-width: 600px)' });
+  const { isDesktop } = useContext(MediaQueryContext);
 
   useEffect(() => {
     fetchData().then(({ categories, subjects, types }) => {
@@ -177,7 +176,7 @@ const UploadPage = () => {
 
           <input
             ref={inputFileRef}
-            width={isMobile ? '90%' : '30%'}
+            width={isDesktop ? '30%' : '90%'}
             type='file'
             accept='application/pdf'
             // , text/plain, application/vnd.openxmlformats-officedocument.wordprocessingml.document

--- a/holy-grail-frontend/src/providers/MediaQueryProvider.tsx
+++ b/holy-grail-frontend/src/providers/MediaQueryProvider.tsx
@@ -1,0 +1,12 @@
+import React, { createContext, useEffect, useState } from 'react';
+import { useMediaQuery } from '@mui/material';
+
+const MediaQueryContext = createContext({ isDesktop: false });
+
+export const MediaQueryProvider = ({ children }: { children: React.ReactNode }) => {
+  const isDesktop = useMediaQuery('(min-width: 600px)');
+
+  return <MediaQueryContext.Provider value={{ isDesktop }}>{children}</MediaQueryContext.Provider>;
+};
+
+export default MediaQueryContext;


### PR DESCRIPTION
this PR makes ``isDesktop`` globally consistent and available with ``useContext``. Removed inconsistent usage of chakra's ``useBreakPointValue`` and mui's ``useMediaQuery`` with inconsistent sizing to determine if a viewport is a desktop of a mobile device.