### PR TITLE
fix(terraform): enable fine-grained access control for OpenSearch

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -33,12 +33,14 @@ module "s3" {
 }
 
 module "opensearch" {
-  source                   = "./opensearch"
-  app_name                 = var.app_name
-  region                   = var.region
-  opensearch_enabled       = var.opensearch_enabled
-  opensearch_instance_type = var.opensearch_instance_type
-  opensearch_volume_size   = var.opensearch_volume_size
+  source                     = "./opensearch"
+  app_name                   = var.app_name
+  region                     = var.region
+  opensearch_enabled         = var.opensearch_enabled
+  opensearch_instance_type   = var.opensearch_instance_type
+  opensearch_volume_size     = var.opensearch_volume_size
+  opensearch_master_user     = var.opensearch_master_user
+  opensearch_master_password = var.opensearch_master_password
 }
 
 module "ecs" {

--- a/terraform/opensearch/main.tf
+++ b/terraform/opensearch/main.tf
@@ -28,6 +28,15 @@ resource "aws_opensearch_domain" "main" {
     tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
   }
 
+  advanced_security_options {
+    enabled                        = true
+    internal_user_database_enabled = true
+    master_user_options {
+      master_user_name     = var.opensearch_master_user
+      master_user_password = var.opensearch_master_password
+    }
+  }
+
   access_policies = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/terraform/opensearch/variable.tf
+++ b/terraform/opensearch/variable.tf
@@ -25,3 +25,16 @@ variable "opensearch_volume_size" {
   type        = number
   default     = 10
 }
+
+variable "opensearch_master_user" {
+  description = "Master username for OpenSearch FGAC"
+  type        = string
+  default     = "admin"
+}
+
+variable "opensearch_master_password" {
+  description = "Master password for OpenSearch FGAC"
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/terraform/variable.tf
+++ b/terraform/variable.tf
@@ -172,3 +172,16 @@ variable "opensearch_volume_size" {
   default     = 10
 }
 
+variable "opensearch_master_user" {
+  description = "Master username for OpenSearch FGAC"
+  type        = string
+  default     = "admin"
+}
+
+variable "opensearch_master_password" {
+  description = "Master password for OpenSearch FGAC"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+


### PR DESCRIPTION
AWS requires either FGAC or restrictive access policies for OpenSearch domains. This adds advanced_security_options with internal user database to satisfy the security requirement.